### PR TITLE
fix: Limit postcss peerDependency version to ^5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "extends": "@sullenor/eslint-config/node"
   },
   "peerDependencies": {
-    "postcss": ">= 5"
+    "postcss": "^5.0.0"
   },
   "devDependencies": {
     "@sullenor/eslint-config": "^1.0.11",


### PR DESCRIPTION
Doesn't work with postcss >= 6. Also tests fail with postcss@6.0.1

This causes errors when postcss-modules-resolve-imports is somewhere in the dependency chain and yarn is used to install packages.