### PR TITLE
root option

### DIFF
--- a/lib/resolveDeps.js
+++ b/lib/resolveDeps.js
@@ -31,7 +31,7 @@ function resolveDeps(ast, result) {
   } = result.opts;
 
   const cwd = dirname(selfPath);
-  const rootDir = dirname(rootPath);
+  const rootDir = rootPath;
   const processor = result.processor;
   const self = graph[selfPath] = graph[selfPath] || {};
 

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -13,6 +13,7 @@
 
 const {plugin} = require('postcss');
 const postcss = require('postcss');
+const path = require('path');
 const resolveDeps = require('./resolveDeps');
 
 const extractPlugin = plugin('extract-plugin', () => resolveDeps);
@@ -26,16 +27,17 @@ module.exports = plugin('postcss-modules-resolve-imports', resolveImportsPlugin)
  * resolve.extensions
  * resolve.modules
  */
-function resolveImportsPlugin({icssExports, resolve = {}} = {}) {
+function resolveImportsPlugin({icssExports, root, resolve = {}} = {}) {
   return resolveImports;
 
   function resolveImports(ast, result) {
     const graph = {};
     const processor = createProcessor(result.processor.plugins);
-    const rootPath = ast.source.input.file;
+    const from = ast.source.input.file;
+    const rootPath = root || path.dirname(from);
     const rootTree = ast.clone({nodes: []});
 
-    resolveDeps(ast, {opts: {from: rootPath, graph, resolve, rootPath, rootTree}, processor});
+    resolveDeps(ast, {opts: {from: from, graph, resolve, rootPath, rootTree}, processor});
 
     if (icssExports) {
       const exportRule = postcss.rule({

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint": "^3",
     "jest": "^20.0.3",
     "postcss": "^6.0.1",
+    "postcss-icss-values": "^2.0.1",
     "postcss-modules-extract-imports": "^1.1.0",
     "postcss-modules-local-by-default": "^1.2.0",
     "postcss-modules-scope": "^1.1.0"

--- a/test/case/resolve-node-module-root/.gitignore
+++ b/test/case/resolve-node-module-root/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/test/case/resolve-node-module-root/__snapshots__/test.js.snap
+++ b/test/case/resolve-node-module-root/__snapshots__/test.js.snap
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`resolve-node-module root defaults to dirname(file) 1`] = `
+"/*  imported from node_modules/button/background.css  */
+
+._background_background {
+  background: red;
+}
+
+/*  imported from node_modules/button/button.css  */
+
+._button_button {
+  font-size: 1em;
+}
+
+/*  imported from source.css  */
+
+._source_test {
+  color: white;
+}
+"
+`;
+
+exports[`resolve-node-module root defaults to dirname(file) 2`] = `
+"/*  imported from background.css  */
+
+._background_background {
+  background: red;
+}
+
+/*  imported from button.css  */
+
+._button_button {
+  font-size: 1em;
+}
+"
+`;
+
+exports[`resolve-node-module root process.cwd 1`] = `
+"/*  imported from test/case/resolve-node-module-root/node_modules/button/background.css  */
+
+._background_background {
+  background: red;
+}
+
+/*  imported from test/case/resolve-node-module-root/node_modules/button/button.css  */
+
+._button_button {
+  font-size: 1em;
+}
+
+/*  imported from test/case/resolve-node-module-root/source.css  */
+
+._source_test {
+  color: white;
+}
+"
+`;
+
+exports[`resolve-node-module root process.cwd 2`] = `
+"/*  imported from test/case/resolve-node-module-root/node_modules/button/background.css  */
+
+._background_background {
+  background: red;
+}
+
+/*  imported from test/case/resolve-node-module-root/node_modules/button/button.css  */
+
+._button_button {
+  font-size: 1em;
+}
+"
+`;

--- a/test/case/resolve-node-module-root/node_modules/button/background.css
+++ b/test/case/resolve-node-module-root/node_modules/button/background.css
@@ -1,0 +1,3 @@
+.background {
+  background: red;
+}

--- a/test/case/resolve-node-module-root/node_modules/button/button.css
+++ b/test/case/resolve-node-module-root/node_modules/button/button.css
@@ -1,0 +1,4 @@
+.button {
+  composes: background from "./background.css";
+  font-size: 1em;
+}

--- a/test/case/resolve-node-module-root/source.css
+++ b/test/case/resolve-node-module-root/source.css
@@ -1,0 +1,4 @@
+.test {
+  composes: button from "button/button.css";
+  color: white;
+}

--- a/test/case/resolve-node-module-root/test.js
+++ b/test/case/resolve-node-module-root/test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const path = require('path');
+const setup = require('../../setup');
+const resolveImports = require('../../../index');
+ 
+describe('resolve-node-module root', () => {
+  test('defaults to dirname(file)', () => {
+    const {resulting: resulting1} = setup(
+      require('postcss-icss-values'),
+      'local-by-default',
+      'extract-imports',
+      'scope',
+      'self'
+    )(__dirname, 'source.css');
+
+    const {resulting: resulting2} = setup(
+      require('postcss-icss-values'),
+      'local-by-default',
+      'extract-imports',
+      'scope',
+      'self'
+    )(__dirname, path.join('node_modules', 'button', 'button.css'));
+
+    expect(resulting1).toMatchSnapshot();
+    expect(resulting2).toMatchSnapshot();
+  });
+  
+  /*
+   * run process() on entry-point css-files in different directories, both of
+   * which import the same file 'node_modules/button/background.css'
+   *
+   * it is important that the locally scoped classnames in the included
+   * 'node_modules/button/background.css' remain the same, no matter
+   * which entry point is used (source.css or button.css)
+   *
+   * (always use relative path of file to rootDir, which is cwd)
+   */
+
+  test('process.cwd', () => {
+    const root = process.cwd();
+    
+    const {resulting: resulting1} = setup(
+      require('postcss-icss-values'),
+      'local-by-default',
+      'extract-imports',
+      'scope',
+      resolveImports({
+        root: root,
+      }),
+    )(__dirname, 'source.css');
+
+    const {resulting: resulting2} = setup(
+      require('postcss-icss-values'),
+      'local-by-default',
+      'extract-imports',
+      'scope',
+      resolveImports({
+        root: root,
+      }),
+    )(__dirname, path.join('node_modules', 'button', 'button.css'));
+
+    expect(resulting1).toMatchSnapshot();
+    expect(resulting2).toMatchSnapshot();
+  });
+});

--- a/test/case/resolve-paths/__snapshots__/test.js.snap
+++ b/test/case/resolve-paths/__snapshots__/test.js.snap
@@ -31,3 +31,35 @@ exports[`resolve-paths 1`] = `
 }
 "
 `;
+
+exports[`resolve-paths custom root 1`] = `
+"/*  imported from test/case/resolve-paths/lib/nested.css  */
+
+/* should be './lib/reset1.css' */
+@import url('./test/case/resolve-paths/lib/reset1.css');
+/* should be './lib/reset2.css' */
+@import './test/case/resolve-paths/lib/reset2.css';
+/* should be 'lib/anything-non-root1' */
+@import url('test/case/resolve-paths/lib/anything-non-root1');
+/* should be 'lib/anything-non-root2' */
+@import 'test/case/resolve-paths/lib/anything-non-root2';
+/* should be '/root-based1' */
+@import url('/root-based1');
+/* should be '/root-based2' */
+@import '/root-based2';
+
+._nested_url-decl
+{
+  /* should be ./lib/spin-icon1.svg */
+  background: url(./test/case/resolve-paths/lib/spin-icon1.svg) 0 0 no-repeat;
+  /* should be ./lib/spin-icon2.svg */
+  background: url('./test/case/resolve-paths/lib/spin-icon2.svg') 0 0 no-repeat;
+}
+
+/*  imported from test/case/resolve-paths/source.css  */
+
+._source_relative
+{
+}
+"
+`;

--- a/test/case/resolve-paths/test.js
+++ b/test/case/resolve-paths/test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const setup = require('../../setup');
+const resolveImports = require('../../../index');
 
 test('resolve-paths', () => {
   const {resulting} = setup(
@@ -9,6 +10,19 @@ test('resolve-paths', () => {
     'scope',
     'self'
   )(__dirname);
+
+  expect(resulting).toMatchSnapshot();
+});
+
+test('resolve-paths custom root', () => {
+  const {resulting} = setup(
+    'local-by-default',
+    'extract-imports',
+    'scope',
+    resolveImports({
+      root: process.cwd(),
+    }),
+  )(__dirname, undefined);
 
   expect(resulting).toMatchSnapshot();
 });

--- a/test/setup.js
+++ b/test/setup.js
@@ -24,9 +24,9 @@ function setup(...plugins) {
 
   return setupCase;
 
-  function setupCase(directory) {
+  function setupCase(directory, file) {
     const runner = postcss(loadedPlugins);
-    const sourcepath = resolve(directory, 'source.css');
+    const sourcepath = resolve(directory, file || 'source.css');
 
     const source = readFileSync(sourcepath, 'utf8');
     const lazyResult = runner.process(source, {from: sourcepath});


### PR DESCRIPTION
by setting a custom root (f.ex. process.cwd) all resolved paths are relative to this directory.

this is useful if runner.process() is called for different entry points, which reference the same module.css file, which then will be resolved to the same path relative to root.

as an example, locally scoped classnames remain the same (as they are generated from the file path) between process runs