### PR TITLE
preserve-symlinks: default to false

### DIFF
--- a/lib/resolveModule.js
+++ b/lib/resolveModule.js
@@ -1,7 +1,14 @@
 'use strict';
 
 const {join, parse, resolve} = require('path');
-const {readFileSync, statSync} = require('fs');
+const {readFileSync, statSync, realpathSync} = require('fs');
+
+const argv = require('minimist')(process.argv.slice(2), {
+  boolean: ['preserve-symlinks'],
+});
+
+const PRESERVE_SYMLINKS = !!argv['preserve-symlinks'] ||
+  process.env.NODE_PRESERVE_SYMLINKS + '' === '1';
 
 exports.applyAliases = applyAliases;
 exports.isDirectory = isDirectory;
@@ -91,6 +98,8 @@ function resolveAsFile(filepath, extensions = []) {
 }
 
 function resolveModule(filepath, {cwd, resolve: resolvecfg = {}}) {
+  const preserveSymlinks = resolvecfg.preserveSymlinks !== undefined
+    ? !!resolvecfg.preserveSymlinks : PRESERVE_SYMLINKS;
   const file = applyAliases(filepath, resolvecfg.alias);
   const dirs = isNodeModule(file)
     ? (resolvecfg.modules || []).concat(nodeModulesPaths(cwd))
@@ -105,6 +114,6 @@ function resolveModule(filepath, {cwd, resolve: resolvecfg = {}}) {
     const result = resolveAsFile(abspath, resolvecfg.extensions) ||
       resolveAsDir(abspath, resolvecfg.mainFile);
 
-    if (result) return result;
+    if (result) return preserveSymlinks ? result : realpathSync(result);
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -110,6 +110,12 @@ Provide additional directories to check the modules in. Should be absolute paths
 Specifies the default filename to be used while resolving directories. Default: `index.css`.
 
 
+`resolve.preserveSymlinks` `boolean`
+
+Wether to resolve symlinks in paths. Defaults to nodejs behaviour: `false`, 
+(parsed from `--preserve-symlinks` or environment variable `PRESERVE_SYMLINKS`).
+
+
 ## Reference Guides
 
 - Interoperable CSS: https://github.com/css-modules/icss

--- a/test/case/opts-preserve-symlink/.gitignore
+++ b/test/case/opts-preserve-symlink/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/test/case/opts-preserve-symlink/__snapshots__/test.js.snap
+++ b/test/case/opts-preserve-symlink/__snapshots__/test.js.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`opts-preserve-symlinks default false 1`] = `
+"/*  imported from lib/button/index.css  */
+
+._index_button {
+  color: green;
+}
+
+/*  imported from source.css  */
+
+._source_continueButton
+{
+  color: green;
+}
+"
+`;
+
+exports[`opts-preserve-symlinks default false 2`] = `
+Object {
+  "continueButton": "_source_continueButton _index_button",
+}
+`;
+
+exports[`opts-preserve-symlinks false 1`] = `
+"/*  imported from lib/button/index.css  */
+
+._index_button {
+  color: green;
+}
+
+/*  imported from source.css  */
+
+._source_continueButton
+{
+  color: green;
+}
+"
+`;
+
+exports[`opts-preserve-symlinks false 2`] = `
+Object {
+  "continueButton": "_source_continueButton _index_button",
+}
+`;
+
+exports[`opts-preserve-symlinks true 1`] = `
+"/*  imported from node_modules/button/index.css  */
+
+._index_button {
+  color: green;
+}
+
+/*  imported from source.css  */
+
+._source_continueButton
+{
+  color: green;
+}
+"
+`;
+
+exports[`opts-preserve-symlinks true 2`] = `
+Object {
+  "continueButton": "_source_continueButton _index_button",
+}
+`;

--- a/test/case/opts-preserve-symlink/lib/button/index.css
+++ b/test/case/opts-preserve-symlink/lib/button/index.css
@@ -1,0 +1,3 @@
+.button {
+  color: green;
+}

--- a/test/case/opts-preserve-symlink/node_modules/button
+++ b/test/case/opts-preserve-symlink/node_modules/button
@@ -1,0 +1,1 @@
+../lib/button/

--- a/test/case/opts-preserve-symlink/source.css
+++ b/test/case/opts-preserve-symlink/source.css
@@ -1,0 +1,5 @@
+.continueButton
+{
+  composes: button from 'button';
+  color: green;
+}

--- a/test/case/opts-preserve-symlink/test.js
+++ b/test/case/opts-preserve-symlink/test.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const resolveImports = require('../../../index');
+const setup = require('../../setup');
+
+test('opts-preserve-symlinks true', () => {
+  const {resulting, exports: tokens} = setup(
+    'local-by-default',
+    'extract-imports',
+    'scope',
+    resolveImports({
+      resolve: {
+        preserveSymlinks: true,
+      },
+    })
+  )(__dirname);
+
+  expect(resulting).toMatchSnapshot();
+  expect(tokens).toMatchSnapshot();
+});
+
+test('opts-preserve-symlinks false', () => {
+  const {resulting, exports: tokens} = setup(
+    'local-by-default',
+    'extract-imports',
+    'scope',
+    resolveImports({
+      resolve: {
+        preserveSymlinks: false,
+      },
+    })
+  )(__dirname);
+
+  expect(resulting).toMatchSnapshot();
+  expect(tokens).toMatchSnapshot();
+});
+
+test('opts-preserve-symlinks default false', () => {
+  const {resulting, exports: tokens} = setup(
+    'local-by-default',
+    'extract-imports',
+    'scope',
+    // nodejs behaviour: defaults to false
+    resolveImports({})
+  )(__dirname);
+
+  expect(resulting).toMatchSnapshot();
+  expect(tokens).toMatchSnapshot();
+});


### PR DESCRIPTION
generate consistent paths for imported files, defaults to nodejs behaviour.

consistency important: f.ex. postcss-icss-selectors :local hashes are based on filenames. browserify defaults to `false` (like nodejs), hence resolved filenames would be different between browserify plugins and `postcss-modules-resolve-imports`.

more info: https://github.com/browserify/browserify/pull/1742 https://github.com/nodejs/node/issues/3402