### PR TITLE
pass result.messages for imported files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -115,6 +115,50 @@ Specifies the default filename to be used while resolving directories. Default: 
 Wether to resolve symlinks in paths. Defaults to nodejs behaviour: `false`, 
 (parsed from `--preserve-symlinks` or environment variable `PRESERVE_SYMLINKS`).
 
+## Messages
+
+This plugin passes `result.messages` for each imported file.
+
+```css
+@value color from "./lib/colors.css";
+
+.myButton {
+  composes: button from './lib/button/button.css';
+  background-color: color;
+}
+```
+
+will output:
+
+```js
+[
+    {
+        plugin: 'postcss-modules-resolve-imports',
+        type: 'import',
+        from: '/foo/bar/lib/button/button.css'
+        file: '/foo/bar/lib/color.css',
+        exports: {
+          // variable
+          color: 'green',
+        },
+    },
+    {
+        plugin: 'postcss-modules-resolve-imports',
+        type: 'import',
+        from: '/foo/bar/source.css',
+        file: '/foo/bar/lib/button/button.css',
+        exports: {
+          // variable from colors.css
+          color: 'green',
+          // local scoped classname from button.css
+          button: '_button_button',
+        },
+    },
+]
+```
+
+You can get access to this variables in `result.messages` also
+in any plugin goes after `postcss-modules-resolve-imports`.
 
 ## Reference Guides
 

--- a/src/sync.js
+++ b/src/sync.js
@@ -32,10 +32,21 @@ function resolveImportsPlugin({icssExports, resolve = {}} = {}) {
   function resolveImports(ast, result) {
     const graph = {};
     const processor = createProcessor(result.processor.plugins);
+    const messages = result.messages;
     const rootPath = ast.source.input.file;
     const rootTree = ast.clone({nodes: []});
 
-    resolveDeps(ast, {opts: {from: rootPath, graph, resolve, rootPath, rootTree}, processor});
+    resolveDeps(ast, {
+      opts: {
+        from: rootPath,
+        graph,
+        resolve,
+        rootPath,
+        rootTree,
+      },
+      processor,
+      messages,
+    });
 
     if (icssExports) {
       const exportRule = postcss.rule({

--- a/test/case/messages-imported-files/lib/button/button.css
+++ b/test/case/messages-imported-files/lib/button/button.css
@@ -1,0 +1,5 @@
+@value color from "../color.css";
+
+.button {
+  background-color: color;
+}

--- a/test/case/messages-imported-files/lib/button/message.css
+++ b/test/case/messages-imported-files/lib/button/message.css
@@ -1,0 +1,5 @@
+@value color from "../color.css";
+
+.message {
+  background-color: color;
+}

--- a/test/case/messages-imported-files/lib/color.css
+++ b/test/case/messages-imported-files/lib/color.css
@@ -1,0 +1,1 @@
+@value color: green;

--- a/test/case/messages-imported-files/source.css
+++ b/test/case/messages-imported-files/source.css
@@ -1,0 +1,13 @@
+
+
+.continueMessage {
+  composes: message from './lib/button/message.css';
+}
+
+.continueMessage2 {
+  composes: message from './lib/button/message.css';
+}
+
+.continueButton {
+  composes: button from './lib/button/button.css';
+}

--- a/test/case/messages-imported-files/test.js
+++ b/test/case/messages-imported-files/test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const setup = require('../../setup');
+const path = require('path');
+
+test('messages-imported-files', () => {
+  let {messages} = setup(
+    'values',
+    'local-by-default',
+    'extract-imports',
+    'scope',
+    'self'
+  )(__dirname);
+
+  messages = messages
+    .filter(m => m.plugin === 'postcss-modules-resolve-imports');
+
+  expect(messages).toEqual([
+    {
+      plugin: 'postcss-modules-resolve-imports',
+      type: 'import',
+      from: path.join(__dirname, 'lib/button/message.css'),
+      file: path.join(__dirname, 'lib/color.css'),
+      exports: {
+        color: 'green',
+      },
+    },
+    {
+      plugin: 'postcss-modules-resolve-imports',
+      type: 'import',
+      from: path.join(__dirname, 'source.css'),
+      file: path.join(__dirname, 'lib/button/message.css'),
+      exports: {
+        color: 'green',
+        message: '_message_message',
+      },
+    },
+    {
+      plugin: 'postcss-modules-resolve-imports',
+      type: 'import',
+      from: path.join(__dirname, 'lib/button/button.css'),
+      file: path.join(__dirname, 'lib/color.css'),
+      exports: {
+        color: 'green',
+      },
+    },
+    {
+      plugin: 'postcss-modules-resolve-imports',
+      type: 'import',
+      from: path.join(__dirname, 'source.css'),
+      file: path.join(__dirname, 'lib/button/button.css'),
+      exports: {
+        color: 'green',
+        button: '_button_button',
+      },
+    },
+  ]);
+});

--- a/test/setup.js
+++ b/test/setup.js
@@ -37,6 +37,7 @@ function setup(...plugins) {
       exports: lazyResult.root.exports,
       resulting: lazyResult.css.replace(/\r/g, ''),
       source,
+      messages: lazyResult.messages,
     };
   }
 }


### PR DESCRIPTION
provide information about imported files (and as a bonus: their exports) through result.messages.

useful for filewatchers like f.ex. `watchify`, which by default only know about the top-level `require('index.css')` file.

also, if running postcss multiple times on different css files (which :import the same files), we need to know the dependencies to generate correctly ordered css output. f.ex. see: https://github.com/carlhopf/postcssify2/blob/d6f947eb20f7441c6cd03b1e5fa020611cb0a2a5/index.js#L26-L47

test inlcuded and readme updated :)