### PR TITLE
migrate postcss 8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "extends": "@sullenor/eslint-config/node"
   },
   "peerDependencies": {
-    "postcss": "^6.0.0"
+    "postcss": "^8.0.0"
   },
   "devDependencies": {
     "@sullenor/eslint-config": "^1.0.11",
@@ -34,7 +34,8 @@
     "gulp-babel": "^7.0.0",
     "gulp-debug": "^3.1.0",
     "jest": "^20.0.3",
-    "postcss": "^6.0.1",
+    "postcss": "^8.0.0",
+    "postcss-focus": "^5.0.1",
     "postcss-icss-values": "2.0.1",
     "postcss-modules-extract-imports": "^1.1.0",
     "postcss-modules-local-by-default": "^1.2.0",

--- a/src/sync.js
+++ b/src/sync.js
@@ -11,13 +11,12 @@
  * @see  http://api.postcss.org/AtRule.html#walkRules
  */
 
-const {plugin} = require('postcss');
 const postcss = require('postcss');
 const resolveDeps = require('./resolveDeps');
 
-const extractPlugin = plugin('extract-plugin', () => resolveDeps);
+const extractPlugin = resolveDeps;
 
-module.exports = plugin('postcss-modules-resolve-imports', resolveImportsPlugin);
+module.exports = resolveImportsPlugin;
 
 /**
  * dangerouslyPrevailCyclicDepsWarnings
@@ -27,7 +26,12 @@ module.exports = plugin('postcss-modules-resolve-imports', resolveImportsPlugin)
  * resolve.modules
  */
 function resolveImportsPlugin({icssExports, resolve = {}} = {}) {
-  return resolveImports;
+  return {
+    postcssPlugin: 'postcss-modules-resolve-imports',
+    Once(root, {result}) {
+      resolveImports(root, result);
+    },
+  };
 
   function resolveImports(ast, result) {
     const graph = {};
@@ -73,3 +77,5 @@ function createProcessor(plugins) {
 function bySelfName(plugin) {
   return plugin.postcssPlugin === 'postcss-modules-resolve-imports';
 }
+
+module.exports.postcss = true;


### PR DESCRIPTION
Fixed a warning message by following https://evilmartians.com/chronicles/postcss-8-plugin-migration

```
extract-plugin: postcss.plugin was deprecated. Migration guide:
https://evilmartians.com/chronicles/postcss-8-plugin-migration
postcss-modules-resolve-imports: postcss.plugin was deprecated. Migration guide:
https://evilmartians.com/chronicles/postcss-8-plugin-migration
```

